### PR TITLE
bump swift version

### DIFF
--- a/cuid.podspec
+++ b/cuid.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
   s.ios.deployment_target = '10.0'
-  s.swift_version = '3.2'
+  s.swift_version = '4.2'
   
 
   s.source_files = 'cuid/**/*'


### PR DESCRIPTION
There's no reason this needs to be marked as Swift 3.2. Upgrading to 4.2 will allow it to work with new Xcode which depricated Swift versions lower than 4.2